### PR TITLE
FIX ensure null is not passed to trim() expecting string

### DIFF
--- a/src/Controllers/RobotsController.php
+++ b/src/Controllers/RobotsController.php
@@ -53,7 +53,7 @@ class RobotsController extends Controller
     public function custom()
     {
         $site = $this->getRobotsSite();
-        $custom = trim($site->RobotsContent);
+        $custom = trim($site->getField('RobotsContent') ?? '');
 
         if (!$custom || empty($custom)) {
             return $this->disallow();


### PR DESCRIPTION
Resolves [Deprecated] trim(): Passing null to parameter #1 ($string) of type string is deprecated