### PR TITLE
A fix, a hook, a modification

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -23,7 +23,7 @@ Only:
 ---
 Symbiote\Multisites\Model\Site:
   extensions:
-    - Innoweb\Robots\Extensions\ConfigExtension
+    innowebRobotsConfig: Innoweb\Robots\Extensions\ConfigExtension
 
 ---
 Name: innoweb-robots-configured-multisites
@@ -33,7 +33,7 @@ Only:
 
 Fromholdio\ConfiguredMultisites\Model\Site:
   extensions:
-    - Innoweb\Robots\Extensions\ConfigExtension
+    innowebRobotsConfig: Innoweb\Robots\Extensions\ConfigExtension
 
 ---
 Name: innoweb-robots-nomultisites
@@ -44,4 +44,4 @@ Except:
 ---
 Silverstripe\SiteConfig\SiteConfig:
   extensions:
-    - Innoweb\Robots\Extensions\ConfigExtension
+    innowebRobotsConfig: Innoweb\Robots\Extensions\ConfigExtension

--- a/src/Controllers/RobotsController.php
+++ b/src/Controllers/RobotsController.php
@@ -169,7 +169,7 @@ class RobotsController extends Controller
             $googleSitemap = GoogleSitemap::singleton();
             $isFiltered = (bool) $googleSitemap->config()->get('use_show_in_search');
             $filterFieldName = 'ShowInSearch';
-            if (method_exists(GoogleSitemap::class, 'getFilterFieldName')) {
+			if (GoogleSitemap::singleton()->hasMethod('getFilterFieldName')) {
                 $filterFieldName = $googleSitemap->getFilterFieldName();
             }
             if ($isFiltered) {

--- a/src/Extensions/ConfigExtension.php
+++ b/src/Extensions/ConfigExtension.php
@@ -120,6 +120,7 @@ class ConfigExtension extends Extension
             $disallowedOutputField->displayIf('RobotsMode')->isEqualTo(RobotsController::MODE_DISALLOW);
         }
 
+		$this->owner->invokeWithExtensions('updateRobotsCMSFields', $fields);
         return $fields;
     }
 

--- a/src/Extensions/ConfigExtension.php
+++ b/src/Extensions/ConfigExtension.php
@@ -136,10 +136,11 @@ class ConfigExtension extends Extension
         } elseif (class_exists('Fromholdio\ConfiguredMultisites\Multisites')) {
             $configs = \Fromholdio\ConfiguredMultisites\Model\Site::get();
         } else {
-            $configs = SiteConfig::get();
+			$class = get_class($this->owner);
+			$configs = $class::get()->limit(1);
         }
         // update configs if required
-        if ($configs && $configs->exists()) {
+		if ($configs->count() > 0) {
             foreach ($configs as $config) {
                 if (!$config->RobotsMode) {
                     if ($config->RobotsContent) {


### PR DESCRIPTION
Can split these out down the track and resubmit them then if you'd prefer! But I think they're pretty innocuous so thought I'd PR this branch and give you the option.

These minor tweaks
- A fix for the getFilterFieldName check
- Adding an extension hook for the CMS fields
- Adding 'innowebRobotsConfig' key to config.yml-applied extensions, for override by /app and external mods
- Adjustment to how the code finds its fallback 'Config' object - rather than hard-coding SiteConfig, which is the class being extended in ConfigExtension, this instead uses the class of the object being extended. So zero change - it's SiteConfig receiving the ConfigExtension and so it returns SiteConfig, but if I used the config key above to not apply it to SiteConfig, and instead to my own SEOConfig data object, this snippet would give me back an SEOConfig rather than a hard-coded SiteConfig.

That got convoluted, hopefully it makes sense!